### PR TITLE
Cleanup gemspec and reduce gem size

### DIFF
--- a/tty-spinner.gemspec
+++ b/tty-spinner.gemspec
@@ -4,20 +4,18 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tty/spinner/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "tty-spinner"
+  spec.name          = 'tty-spinner'
   spec.version       = TTY::Spinner::VERSION
-  spec.authors       = ["Piotr Murach"]
-  spec.email         = ["pmurach@gmail.com"]
+  spec.authors       = ['Piotr Murach']
+  spec.email         = ['pmurach@gmail.com']
   spec.summary       = %q{A terminal spinner for tasks that have non-deterministic time frame.}
   spec.description   = %q{A terminal spinner for tasks that have non-deterministic time frame.}
-  spec.homepage      = "https://github.com/peter-murach/tty-spinner"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/peter-murach/tty-spinner'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files         = Dir['lib/**/*.rb', 'LICENSE.txt', 'README.md']
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
- I saw you prefer single quoted over gem, so I fix here too.
- Change `spec.files` to contain only lib, license and readme, other file are not necessary for runtime or info.
- Remove `spec.executables` because gem hasn't any.
- Remove `spec.test_files` because of deprecation.
