### PR TITLE
Bugfix: Restore hidden cursor

### DIFF
--- a/examples/hide_cursor.rb
+++ b/examples/hide_cursor.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+require 'tty-spinner'
+require 'pastel'
+
+pastel = Pastel.new
+
+format = "[#{pastel.yellow(':spinner')}] " + pastel.yellow("Task name")
+spinner = TTY::Spinner.new(format, success_mark: pastel.green('+'), hide_cursor: true)
+10.times do
+  spinner.spin
+  sleep(0.1)
+end
+spinner.success(pastel.green("(successful)"))

--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -186,7 +186,7 @@ module TTY
     #
     # @api public
     def stop(stop_message = '')
-      if @hide_cursor && spinning?
+      if @hide_cursor
         write(ECMA_CSI + DEC_TCEM + DEC_SET, false)
       end
       @done = true

--- a/spec/unit/hide_cursor_spec.rb
+++ b/spec/unit/hide_cursor_spec.rb
@@ -16,4 +16,32 @@ RSpec.describe TTY::Spinner, ':hide_cursor' do
       "\e[?25h\e[1G\\\n"
     ].join)
   end
+
+  it "restores cursor on success" do
+    spinner = TTY::Spinner.new(output: output, hide_cursor: true)
+    4.times { spinner.spin }
+    spinner.success('success')
+    output.rewind
+    expect(output.read).to eq([
+      "\e[?25l\e[1G|",
+      "\e[1G/",
+      "\e[1G-",
+      "\e[1G\\",
+      "\e[?25h\e[1G\u2714 success\n"
+    ].join)
+  end
+
+  it "restores cursor on error" do
+    spinner = TTY::Spinner.new(output: output, hide_cursor: true)
+    4.times { spinner.spin }
+    spinner.error('error')
+    output.rewind
+    expect(output.read).to eq([
+      "\e[?25l\e[1G|",
+      "\e[1G/",
+      "\e[1G-",
+      "\e[1G\\",
+      "\e[?25h\e[1G\u2716 error\n"
+    ].join)
+  end
 end


### PR DESCRIPTION
Previously it would not be restored when stopping the
spinner via #success or #error.