### PR TITLE
Upgrade TTY::Cursor and add top level spinner option

### DIFF
--- a/examples/multi_with_inset.rb
+++ b/examples/multi_with_inset.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+require 'tty-spinner'
+
+spinners = TTY::Spinner::Multi.new(message: "[:spinner] Top level spinner")
+
+sp1 = spinners.register "[:spinner] one"
+sp2 = spinners.register "[:spinner] two"
+sp3 = spinners.register "[:spinner] three"
+
+spinners.auto_spin
+sp1.auto_spin
+sp2.auto_spin
+sp3.auto_spin
+
+sleep(2)
+
+sp1.success
+sleep 1
+sp2.success
+
+sleep 1
+
+sp3.error
+
+spinners.error

--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -272,7 +272,7 @@ module TTY
       end
 
       write(data, true)
-      write("\n", false) unless @clear
+      write("\n", false) unless @clear || @multispinner
     ensure
       @state      = :stopped
       @done       = true
@@ -354,7 +354,7 @@ module TTY
             @first_run = false
           else
             output.print TTY::Cursor.save
-            output.print TTY::Cursor.up lines_up
+            output.print TTY::Cursor.up(lines_up)
             yield if block_given?
             output.print TTY::Cursor.restore
           end
@@ -372,7 +372,11 @@ module TTY
     def write(data, clear_first = false)
       execute_on_line do
         output.print(ECMA_CSI + '1' + ECMA_CHA) if clear_first
-        output.print(data)
+
+        # If there's a top level spinner, print with inset
+        characters_in = @multispinner.nil? ? "" : @multispinner.line_inset(self)
+
+        output.print(characters_in + data)
         output.flush
       end
     end

--- a/spec/unit/multi/top_level_spinner_spec.rb
+++ b/spec/unit/multi/top_level_spinner_spec.rb
@@ -1,0 +1,57 @@
+# coding: utf-8
+#
+
+RSpec.describe TTY::Spinner::Multi, '#line_inset' do
+  let(:output) { StringIO.new('', 'w+') }
+
+  it "returns the empty string when there's no top level spinner" do
+    spinners = TTY::Spinner::Multi.new(output: output)
+    allow_any_instance_of(TTY::Spinner).to receive(:add_multispinner)
+
+    spinner = spinners.register ""
+
+    expect(spinners.line_inset(spinner)).to eq('')
+  end
+
+  it "returns the empty string for the top level spinner" do
+    spinners = TTY::Spinner::Multi.new(output: output, message: "Top level spinner")
+    allow_any_instance_of(TTY::Spinner).to receive(:add_multispinner)
+
+    spinners.register ""
+
+    expect(spinners.line_inset(spinners.top_level_spinner)).to eq('')
+  end
+
+  it "returns four spaces when there is a top level spinner" do
+    spinners = TTY::Spinner::Multi.new(output: output, message: "Top level spinner")
+    allow_any_instance_of(TTY::Spinner).to receive(:add_multispinner)
+
+    spinner = spinners.register ""
+
+    expect(spinners.line_inset(spinner)).to eq('    ')
+  end
+end
+
+RSpec.describe TTY::Spinner::Multi, '#auto_spin' do
+  let(:output) { StringIO.new('', 'w+') }
+
+  it "raises and exception when #auto_spin is called without a top level spinner" do
+    spinners = TTY::Spinner::Multi.new(output: output)
+    allow_any_instance_of(TTY::Spinner).to receive(:add_multispinner)
+
+    spinners.register ""
+
+    expect { spinners.auto_spin }.to raise_exception
+  end
+
+  it "doesn't raise exception" do
+    spinners = TTY::Spinner::Multi.new(output: output, message: "Top level spinner")
+    allow_any_instance_of(TTY::Spinner).to receive(:add_multispinner)
+    allow_any_instance_of(TTY::Spinner).to receive(:auto_spin)
+
+    spinners.register ""
+
+    expect { spinners.auto_spin }.not_to raise_exception
+  end
+
+end

--- a/spec/unit/spin_spec.rb
+++ b/spec/unit/spin_spec.rb
@@ -47,12 +47,16 @@ RSpec.describe TTY::Spinner, '#spin' do
   it "spins with newline when it has a MultiSpinner" do
     multi_spinner = double("MultiSpinner")
     allow(multi_spinner).to receive(:count_line_offset).and_return(1, 1, 2, 1)
+    allow(multi_spinner).to receive(:line_inset).and_return("")
 
     spinner = TTY::Spinner.new(output: output, interval: 100)
     spinner.add_multispinner(multi_spinner, 0)
 
     spinner2 = TTY::Spinner.new(output: output, interval: 100)
     spinner2.add_multispinner(multi_spinner, 1)
+
+    save = Gem.win_platform? ? "\e[s" : "\e7"
+    restore = Gem.win_platform? ? "\e[u" : "\e8"
 
     spinner.spin
     spinner2.spin
@@ -66,10 +70,10 @@ RSpec.describe TTY::Spinner, '#spin' do
     expect(output.read).to eq([
       "\e[1G|\n",
       "\e[1G|\n",
-      "\e[s",           # save position
+      save,
       "\e[2A",          # up 2 lines
       "\e[1G/",
-      "\e[u"            # restore position
+      restore
     ].join)
 
     spinner2.spin
@@ -77,14 +81,14 @@ RSpec.describe TTY::Spinner, '#spin' do
     expect(output.read).to eq([
       "\e[1G|\n",
       "\e[1G|\n",
-      "\e[s",           # save position
+      save,
       "\e[2A",          # up 2 lines
       "\e[1G/",
-      "\e[u",           # restore position
-      "\e[s",           # save position
+      restore,
+      save,
       "\e[1A",          # up 1 line
       "\e[1G/",
-      "\e[u"            # restore position
+      restore
     ].join)
 
   end

--- a/tty-spinner.gemspec
+++ b/tty-spinner.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb', 'LICENSE.txt', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'tty-cursor'
+  spec.add_runtime_dependency 'tty-cursor', '>= 0.5.0'
   spec.add_development_dependency 'bundler', '>= 1.5.0', '< 2.0'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Terminal.app does not respect ANSI cursor save and restore sequences so
instead this commit moves the cursor explicitly with up and down
commands to ensure compatibility.

I was initially put on this track by [this Github issue](https://github.com/sindresorhus/ansi-escapes/issues/1)

I added this example to test
```ruby
require 'tty-spinner'

print "hello\n"

sleep 1

print TTY::Cursor.save
print TTY::Cursor.prev_line

sleep 1

print "Hello world"
print TTY::Cursor.restore

sleep 1
```

The above example in tmux (on Terminal.app)
![tmux_cursor_save_and_restore](https://user-images.githubusercontent.com/4520807/28738843-d87a6a2c-73aa-11e7-9645-d64f4d7190b4.gif)

The above example in Terminal.app directly
![terminal_cursor_save_and_restore](https://user-images.githubusercontent.com/4520807/28738846-e0104ad6-73aa-11e7-9716-1bdf66c5b7f4.gif)

