### PR TITLE
Why instance_eval?

### DIFF
--- a/lib/tty/spinner/multi.rb
+++ b/lib/tty/spinner/multi.rb
@@ -118,7 +118,7 @@ module TTY
         @spinners.each do |spinner|
           if spinner.job?
             spinner.auto_spin
-            jobs << Thread.new { spinner.instance_eval(&spinner.job) }
+            jobs << Thread.new { spinner.job.call(spinner) }
           end
         end
         jobs.each(&:join)


### PR DESCRIPTION
I needed to do something like this with the multi-spinner:

```
class MyClass

  attr_reader :config

  def doit
    ...
    spinners.register("[:spinner] :title") do |spinner|
      spinner.update(title: "#{config.value}")
    ...
  end
end
```

I wasn't sure why the job block was being `instance_eval`ed. Is there a specific reason instead of just calling it?