### PR TITLE
Multi spinner can register a spinner instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Use **TTY::Spinner::Multi** to synchornize multiple spinners:
 spinners = TTY::Spinner::Multi.new("[:spinner] top")
 
 sp1 = spinners.register "[:spinner] one"
+# or sp1 = ::TTY::Spinner.new("[:spinner] one")
 sp2 = spinners.register "[:spinner] two"
 
 sp1.auto_spin
@@ -417,6 +418,9 @@ Create and register a `TTY::Spinner` under the multispinner
 
 ```ruby
 new_spinner = multi_spinner.register("[:spinner] Task 1 name", options)
+# or
+#   spinner = ::TTY::Spinner.new("[:spinner] one")
+#   sp1 = multi_spinner.register(spinner)
 ```
 
 If no options are given it will use the options given to the multi_spinner when it was initialized to create the new spinner.

--- a/lib/tty/spinner/multi.rb
+++ b/lib/tty/spinner/multi.rb
@@ -74,13 +74,24 @@ module TTY
 
       # Register a new spinner
       #
-      # @param [String] pattern
-      #   the pattern used for creating spinner
+      # @param [String, TTY::Spinner] pattern_or_spinner
+      #   the pattern used for creating spinner, or a spinner instance
       #
       # @api public
-      def register(pattern, options = {}, &job)
+      def register(pattern_or_spinner, options = {}, &job)
         observable = options.delete(:observable) { true }
-        spinner = TTY::Spinner.new(pattern, @options.merge(options))
+
+        spinner = if pattern_or_spinner.is_a?(::String)
+                    TTY::Spinner.new(
+                      pattern_or_spinner,
+                      @options.merge(options)
+                    )
+                  elsif pattern_or_spinner.is_a?(::TTY::Spinner)
+                    pattern_or_spinner
+                  else
+                    raise ArgumentError, "Expected a pattern or spinner, " \
+                      "got: #{pattern_or_spinner.class}"
+                  end
 
         synchronize do
           spinner.attach_to(self)

--- a/spec/unit/multi/register_spec.rb
+++ b/spec/unit/multi/register_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe TTY::Spinner::Multi, '#register' do
   let(:output) { StringIO.new('', 'w+') }
 
-  it "registers a TTY::Spinner instance" do
+  it "registers a TTY::Spinner instance from a pattern" do
     spinners = TTY::Spinner::Multi.new(output: output, interval: 100)
     allow_any_instance_of(TTY::Spinner).to receive(:attach_to)
     expect_any_instance_of(TTY::Spinner).to receive(:attach_to)
@@ -12,6 +12,26 @@ RSpec.describe TTY::Spinner::Multi, '#register' do
 
     expect(spinner).to be_instance_of(TTY::Spinner)
     expect(spinners.length).to eq(1)
+  end
+
+  it "registers a TTY::Spinner instance from a spinner instance" do
+    spinners = TTY::Spinner::Multi.new(output: output, interval: 100)
+    spinner_to_register = ::TTY::Spinner.new
+
+    spinner = spinners.register spinner_to_register
+
+    expect(spinner).to eq(spinner_to_register)
+    expect(spinners.length).to eq(1)
+  end
+
+  it "raises an erro when given neither a string or spinner instance" do
+    spinners = TTY::Spinner::Multi.new(output: output, interval: 100)
+
+    expect { spinners.register [] }.
+      to raise_error(
+        ArgumentError,
+        "Expected a pattern or spinner, got: Array"
+      )
   end
 
   it "uses global options to register instance" do


### PR DESCRIPTION
### Describe the change
Modifies the `MultiSpinner#register` to accept a instance of `TTY::Spinner`.

### Why are we doing this?
I have existing spinners that sometimes run by themselves, but that I would like to register with `MultiSpinner` under a specific condition.

### Benefits
More flexibility.

### Drawbacks
Unknown

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
