### PR TITLE
formats: Remove a stray single quote

### DIFF
--- a/lib/tty/spinner/formats.rb
+++ b/lib/tty/spinner/formats.rb
@@ -21,7 +21,7 @@ module TTY
       },
       spin_4: {
         interval: 10,
-        frames: %w{╫ ╪'}
+        frames: %w{╫ ╪}
       },
       pulse: {
         interval: 10,


### PR DESCRIPTION
This PR removes a single quote which I don't think was placed intentionally where it is.

I'm not sure if this `'` was intentional or not, but it renders unsteadily in my terminal; each frame is a different width.  This PR resolves that behavior.