### PR TITLE
Use TTY::Cursor.hide instead of constants

### DIFF
--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -17,9 +17,7 @@ module TTY
     # @raised when attempting to join dead thread
     NotSpinningError = Class.new(StandardError)
 
-    ECMA_CSI = "\x1b[".freeze
-    DEC_TCEM = '?25'.freeze
-    DEC_RST  = 'l'.freeze
+    ECMA_CSI = "\x1b["
 
     MATCHER = /:spinner/
     TICK = '✔'
@@ -374,7 +372,7 @@ module TTY
     # @api private
     def redraw_indent
       if @hide_cursor && !spinning?
-        write(ECMA_CSI + DEC_TCEM + DEC_RST)
+        write(TTY::Cursor.hide)
       end
 
       write("", false)

--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -17,7 +17,9 @@ module TTY
     # @raised when attempting to join dead thread
     NotSpinningError = Class.new(StandardError)
 
-    ECMA_CSI = "\x1b["
+    ECMA_CSI = "\x1b[".freeze
+    DEC_TCEM = '?25'.freeze
+    DEC_RST  = 'l'.freeze
 
     MATCHER = /:spinner/
     TICK = '✔'

--- a/spec/unit/spin_spec.rb
+++ b/spec/unit/spin_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe TTY::Spinner, '#spin' do
           save,
           "\e[1A",
           "--- ",
-          restore,
+          restore
         ].join)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe TTY::Spinner, '#spin' do
           save,
           "\e[1A",
           "--- ",
-          restore,
+          restore
         ].join)
       end
     end


### PR DESCRIPTION
### Describe the change
fixes issue #38 
### Why are we doing this?
crashing is not desirable


