### PR TITLE
Made tty? public (as documented in code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ Optionally you can provide timeout:
 spinner.join(0.5)
 ```
 
+### 2.9 tty?
+
+The spinner will not write any output if the output stream is not a TTY. You can check this with:
+
+```ruby
+spinner.tty?
+```
+
 ## 3. Configuration
 
 There are number of configuration options that can be provided to customise the behaviour of a spinner.

--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -474,6 +474,15 @@ module TTY
       end
     end
 
+    # Check if IO is attached to a terminal
+    #
+    # return [Boolean]
+    #
+    # @api public
+    def tty?
+      output.respond_to?(:tty?) && output.tty?
+    end
+
     private
 
     # Execute a block on the proper terminal line if the spinner is running
@@ -516,15 +525,6 @@ module TTY
         output.print("#{characters_in}#{data}")
         output.flush
       end
-    end
-
-    # Check if IO is attached to a terminal
-    #
-    # return [Boolean]
-    #
-    # @api public
-    def tty?
-      output.respond_to?(:tty?) && output.tty?
     end
 
     # Emit callback

--- a/spec/unit/tty_spec.rb
+++ b/spec/unit/tty_spec.rb
@@ -3,6 +3,6 @@
 RSpec.describe TTY::Spinner, "#tty?" do
   it "responds to tty?" do
     spinner = TTY::Spinner.new
-    expect(spinner.tty?).to eq(true)
+    expect(spinner).to respond_to(:tty?)
   end
 end

--- a/spec/unit/tty_spec.rb
+++ b/spec/unit/tty_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Spinner, "#tty?" do
+  it "responds to tty?" do
+    spinner = TTY::Spinner.new
+    expect(spinner.tty?).to eq(true)
+  end
+end


### PR DESCRIPTION
### Describe the change

Makes the `Spinner#tty?` method public.

### Why are we doing this?

This allows users to check if the spinner will produce output and write their own output if not.

### Benefits

See above.

### Drawbacks

It's an extra method to maintain.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
