### PR TITLE
Add trailing_newline option to log

### DIFF
--- a/examples/log.rb
+++ b/examples/log.rb
@@ -7,6 +7,8 @@ spinner = TTY::Spinner.new("[:spinner] processing...", format: :bouncing_ball)
 10.times do |i|
   spinner.log("[#{i}] Task")
   sleep(0.1)
+  spinner.log("Multi\nLine\nLog\n", trailing_newline: false)
+  sleep(0.1)
   spinner.spin
 end
 

--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -504,15 +504,22 @@ module TTY
     #
     # @param [String] text
     #   the message to log out
+    # @param [Boolean] trailing_newline
+    #   automatically add a trailing new line if message is missing one (using LF)
     #
     # @api public
-    def log(text)
+    def log(text, trailing_newline: true)
       synchronize do
         cleared_text = text.to_s.lines.map do |line|
           TTY::Cursor.clear_line + line
         end.join
 
-        write("#{cleared_text}#{"\n" unless cleared_text.end_with?("\n")}", false)
+        if trailing_newline
+          write("#{cleared_text}#{"\n" unless cleared_text.end_with?("\n")}", false)
+        else
+          write(cleared_text, false)
+        end
+
         render
       end
     end

--- a/spec/unit/log_spec.rb
+++ b/spec/unit/log_spec.rb
@@ -57,4 +57,25 @@ RSpec.describe TTY::Spinner, "#log" do
       "\e[2K\e[1Gbar\n"
     ].join)
   end
+
+  context "when trailing_newline is false" do
+    it "logs a message above a spinner" do
+      spinner = TTY::Spinner.new(output: output)
+
+      2.times {
+        spinner.log "foo\r", trailing_newline: false
+        spinner.spin
+      }
+      output.rewind
+
+      expect(output.read).to eq([
+        "\e[2K\e[1Gfoo\r",
+        "\e[1G|",
+        "\e[1G|",
+        "\e[2K\e[1Gfoo\r",
+        "\e[1G/",
+        "\e[1G/"
+      ].join)
+    end
+  end
 end


### PR DESCRIPTION
### Describe the change
Adds `trailing_newline` option to `TTY::Spinner#log`.

### Why are we doing this?
Following discussion on issue #43 

### Benefits
Allow seamless use of `spinner.log("cool feature")` but also more complex feature, like redirecting output of other command.

### Drawbacks
N/A

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked? (rubocop on current master returns `62 files inspected, 102 offenses detected, 64 offenses autocorrectable`)
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
