### PR TITLE
Fix hide_cursor on multi spinners

### DIFF
--- a/lib/tty/spinner.rb
+++ b/lib/tty/spinner.rb
@@ -384,8 +384,8 @@ module TTY
     # Redraw the indent for this spinner, if it exists
     #
     # @api private
-    def redraw_indent
-      if @hide_cursor && !spinning?
+    def redraw_indent(rehide: false)
+      if @hide_cursor && (rehide || !spinning?)
         write(TTY::Cursor.hide)
       end
 

--- a/lib/tty/spinner/multi.rb
+++ b/lib/tty/spinner/multi.rb
@@ -344,6 +344,9 @@ module TTY
           if done?
             @top_spinner.stop if @top_spinner && !error? && !success?
             emit(:done)
+          elsif @options[:hide_cursor]
+            # Undo show cursor done by subspinners
+            @spinners.first.redraw_indent(rehide: true)
           end
         end
       end


### PR DESCRIPTION
### Describe the change
Fix hide_cursor on multi spinners

### Why are we doing this?
When a spinner is done, it writes "show" sequence, leading to cursor reappearance, although others are still spinning.

### Benefits
Rehide the cursor on sub-done.

### Drawbacks

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [X] Changelog updated?
