### PR TITLE
Add manual_stop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,18 @@ The result may look like this:
 └── [✖] two
 ```
 
+If you wish to also have manual control over the top-level spinner, set
+the `manual_stop` option. This keeps the top-level spinner spinning even
+if all currently registered spinners have finished. You can then, for
+example, add more spinners or call `multi_spinner.success` even if a
+spinner has errored.
+
+```ruby
+multi_spinner = TTY::Spinner::Multi.new("[:spinner] top", manual_stop: true)
+```
+
+See also the `examples/multi/multi_manual_stop.rb` example.
+
 #### 5.2.2 auto async tasks
 
 In case when you wish to execute async tasks and update individual spinners automatically, in any order, about their task status use `#register` and pass additional block parameter with the job to be executed.

--- a/examples/multi/multi_manual_stop.rb
+++ b/examples/multi/multi_manual_stop.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/tty-spinner"
+
+spinners = TTY::Spinner::Multi.new("[:spinner] Top level spinner",
+                                   manual_stop: true)
+
+sp1 = spinners.register "[:spinner] one"
+sp1.auto_spin
+
+sleep(2)
+sp1.success
+
+sp2 = spinners.register "[:spinner] two"
+sp3 = spinners.register "[:spinner] three"
+
+sp2.auto_spin
+sp3.auto_spin
+
+sleep(1)
+sp2.error
+sleep(1)
+sp3.success
+
+spinners.error # requires manual stop

--- a/spec/unit/multi/auto_spin_spec.rb
+++ b/spec/unit/multi/auto_spin_spec.rb
@@ -28,5 +28,27 @@ RSpec.describe TTY::Spinner::Multi, "#auto_spin" do
     spinners.auto_spin
 
     expect(jobs).to match_array(%w[one two])
+    expect(spinners.top_spinner.done?).to be(true)
+  end
+
+  context "when manual_stop option is set" do
+    it "keeps the top level spinner spinning" do
+      spinners = TTY::Spinner::Multi.new("top", output: output, manual_stop: true)
+      jobs = []
+
+      spinners.register("one") { |sp| jobs << "one"; sp.success }
+      spinners.register("two") { |sp| jobs << "two"; sp.success }
+
+      spinners.auto_spin
+
+      spinner = spinners.register("three") { |sp| jobs << "three"; sp.success }
+      spinner.run
+
+      expect(jobs).to match_array(%w[one two three])
+
+      expect(spinners.top_spinner.done?).to be(false)
+      spinners.success
+      expect(spinners.top_spinner.done?).to be(true)
+    end
   end
 end


### PR DESCRIPTION
### Describe the change

This adds the `manual_stop` option (defaulting to `false`) to multi spinners, so that the top-level spinner will never stop spinning until it is stopped manually.

See `examples/multi/multi_manual_stop.rb`:

https://github.com/user-attachments/assets/760cda14-de46-485b-a656-3743d4409262

### Why are we doing this?

Closes #45 

In our specific use case, we’re working on [integrating tty-spinner into our development tool GDK](https://gitlab.com/gitlab-org/gitlab-development-kit/-/merge_requests/3814) to work with Rake and later allow parallel updates. We only want to show spinners for currently running tasks, and not pre-register spinners in case we later want to skip them to reduce visual noise. By gaining manual control over the top-level spinner, we can keep it spinning until all tasks have finished.

### Benefits

Present a better user experience in use cases such as our’s or the one detailed in #45.

### Drawbacks

Manual control over the top level spinner could be confusing for a developer, so they might end up keeping the spinner running indefinitely, breaking the output until the process exits. Though this can already happen if not all registered are stopped.

### Requirements

- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [ ] Changelog updated?
