### PR TITLE
[bugfix] Updating examples

### DIFF
--- a/examples/clear.rb
+++ b/examples/clear.rb
@@ -2,7 +2,12 @@
 
 require_relative "../lib/tty-spinner"
 
-spinner = TTY::Spinner.new("[:spinner] Task name", format: :bouncing_ball)
+spinner = TTY::Spinner.new(
+  "[:spinner] Task name",
+  clear: true,
+  format: :bouncing_ball
+)
+
 20.times do
   spinner.spin
   sleep(0.1)

--- a/examples/multi/custom_style.rb
+++ b/examples/multi/custom_style.rb
@@ -4,9 +4,9 @@ require_relative "../../lib/tty-spinner"
 
 opts = {
   style: {
-    top: ". ",
-    middle: "|-> ",
-    bottom: "|__ "
+    top:    "╭─➤ ",
+    middle: "├──➤ ",
+    bottom: "╰──➤ "
   },
   format: :bouncing_ball
 }

--- a/examples/multi/threaded.rb
+++ b/examples/multi/threaded.rb
@@ -1,22 +1,29 @@
 # frozen_string_literal: true
 
 require_relative "../../lib/tty-spinner"
+require "pastel"
 
-def spinner_options
-  [
-    ":spinner \e[1mNo\e[0m :number Row :line",
-    format: :dots,
-    error_mark: "✖",
-    success_mark: "\e[1m\e[32m✓\e[0m\e[0m"
-  ]
+@pastel = Pastel.new
+
+def spinner_text
+  ":spinner #{@pastel.bold('No')} :number \t #{@pastel.bold('Row')} :line"
 end
 
-spinners = TTY::Spinner::Multi.new(*spinner_options)
+def spinner_options
+  {
+    format: :dots,
+    hide_cursor: true,
+    error_mark: @pastel.red.bold("✖"),
+    success_mark: @pastel.green.bold("✓")
+  }
+end
+
+spinners = TTY::Spinner::Multi.new(spinner_text, **spinner_options)
 threads = []
 
 20.times do |i|
   threads << Thread.new do
-    spinner = spinners.register(*spinner_options)
+    spinner = spinners.register(spinner_text, **spinner_options)
     sleep Random.rand(0.1..0.3)
 
     10.times do
@@ -24,6 +31,10 @@ threads = []
       spinner.update(number: "(#{i})", line: spinner.row)
       spinner.spin
     end
+
+    # Randomize conclusion
+    conclusion = %i[success error].sample
+    spinner.send(conclusion)
   end
 end
 


### PR DESCRIPTION
# What
A few of the examples could do with a few improvements:
- `clear.rb` wasn't setting `clear: true`, so not exhibiting the feature
- updated the glyphs for `custom_style.rb`
- `multi/threaded.rb` was broken, due to [Ruby 3.0 changes](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).  I've fixed it and added random success/errors to better demonstrate the example.